### PR TITLE
Redmine 4.0 compatibility

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -5,7 +5,7 @@ Redmine::Plugin.register :plantuml do
   version '0.5.1'
   url 'https://github.com/dkd/plantuml'
 
-  requires_redmine version: '2.6'..'3.4'
+  requires_redmine version: '2.6'..'4.0'
 
   settings(partial: 'settings/plantuml',
            default: { 'plantuml_binary' => {}, 'cache_seconds' => '0', 'allow_includes' => false })

--- a/lib/plantuml_helper_patch.rb
+++ b/lib/plantuml_helper_patch.rb
@@ -2,11 +2,10 @@ require_dependency 'redmine/wiki_formatting/textile/helper'
 
 module PlantumlHelperPatch
   def self.included(base) # :nodoc:
-    base.send(:include, HelperMethodsWikiExtensions)
+    base.send(:prepend, HelperMethodsWikiExtensions)
 
     base.class_eval do
       unloadable # Send unloadable so it will not be unloaded in development
-      alias_method_chain :heads_for_wiki_formatter, :plantuml
     end
   end
 end
@@ -14,8 +13,9 @@ end
 module HelperMethodsWikiExtensions
   # extend the editor Toolbar for adding a plantuml button
   # overwrite this helper method to have full control about the load order
-  def heads_for_wiki_formatter_with_plantuml
+  def heads_for_wiki_formatter
     return if @heads_for_wiki_plantuml_included
+    super
     content_for :header_tags do
       javascript_include_tag('jstoolbar/jstoolbar-textile.min') +
         javascript_include_tag("jstoolbar/lang/jstoolbar-#{current_language.to_s.downcase}") +


### PR DESCRIPTION
Replaces the deprecated `alias_method_chain` to be compatible with the new Redmine 4.0 relase.