### PR TITLE
separate patches for markdown and textile toolbar

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -35,8 +35,11 @@ end
 Rails.configuration.to_prepare do
   # Guards against including the module multiple time (like in tests)
   # and registering multiple callbacks
+  unless Redmine::WikiFormatting::Textile::Helper.included_modules.include? PlantumlTextileHelperPatch
+    Redmine::WikiFormatting::Textile::Helper.send(:include, PlantumlTextileHelperPatch)
+  end
 
-  unless Redmine::WikiFormatting::Textile::Helper.included_modules.include? PlantumlHelperPatch
-    Redmine::WikiFormatting::Textile::Helper.send(:include, PlantumlHelperPatch)
+  unless Redmine::WikiFormatting::Markdown::Helper.included_modules.include? PlantumlMarkdownHelperPatch
+    Redmine::WikiFormatting::Markdown::Helper.send(:include, PlantumlMarkdownHelperPatch)
   end
 end

--- a/lib/plantuml_markdown_helper_patch.rb
+++ b/lib/plantuml_markdown_helper_patch.rb
@@ -1,0 +1,25 @@
+require_dependency 'redmine/wiki_formatting/markdown/helper'
+
+module PlantumlMarkdownHelperPatch
+  def self.included(base) # :nodoc:
+    base.send(:prepend, HelperMethodsWikiExtensions)
+
+    base.class_eval do
+      unloadable # Send unloadable so it will not be unloaded in development
+    end
+  end
+end
+
+module HelperMethodsWikiExtensions
+  # extend the editor Toolbar for adding a plantuml button
+  # overwrite this helper method to have full control about the load order
+  def heads_for_wiki_formatter
+    return if @heads_for_wiki_plantuml_included
+    super
+    content_for :header_tags do
+        javascript_include_tag('plantuml.js', plugin: 'plantuml') +
+        stylesheet_link_tag('plantuml.css', plugin: 'plantuml')
+    end
+    @heads_for_wiki_plantuml_included = true
+  end
+end

--- a/lib/plantuml_textile_helper_patch.rb
+++ b/lib/plantuml_textile_helper_patch.rb
@@ -1,6 +1,6 @@
 require_dependency 'redmine/wiki_formatting/textile/helper'
 
-module PlantumlHelperPatch
+module PlantumlTextileHelperPatch
   def self.included(base) # :nodoc:
     base.send(:prepend, HelperMethodsWikiExtensions)
 
@@ -17,9 +17,6 @@ module HelperMethodsWikiExtensions
     return if @heads_for_wiki_plantuml_included
     super
     content_for :header_tags do
-      javascript_include_tag('jstoolbar/jstoolbar-textile.min') +
-        javascript_include_tag("jstoolbar/lang/jstoolbar-#{current_language.to_s.downcase}") +
-        stylesheet_link_tag('jstoolbar') +
         javascript_include_tag('plantuml.js', plugin: 'plantuml') +
         stylesheet_link_tag('plantuml.css', plugin: 'plantuml')
     end


### PR DESCRIPTION
This pull request adds the PlantUML icon to the markdown toolbar, plus additional refactoring.