### PR TITLE
update compatible redmine version to 4.2

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -5,7 +5,7 @@ Redmine::Plugin.register :plantuml do
   version '0.5.1'
   url 'https://github.com/dkd/plantuml'
 
-  requires_redmine version: '2.6'..'4.1'
+  requires_redmine version: '2.6'..'4.2'
 
   settings(partial: 'settings/plantuml',
            default: { 'plantuml_binary' => {}, 'cache_seconds' => '0', 'allow_includes' => false })


### PR DESCRIPTION
Plantuml installation fails in Redmine 4.2.1 environment

> bundle exec rake redmine:plugins:migrate RAILS_ENV=production
> rake aborted!
> Redmine::PluginRequirementError: plantuml plugin requires a Redmine version between 2.6 and 4.1 but current is 4.2.1.stable

In my Redmine 4.2.1 environment, plantuml is working with this change.
