### PR TITLE
Update compatible Redmine version to 6.0

### DIFF
--- a/app/controllers/plantuml_controller.rb
+++ b/app/controllers/plantuml_controller.rb
@@ -1,5 +1,5 @@
 class PlantumlController < ApplicationController
-  unloadable
+  Rails::VERSION::MAJOR < 5 and unloadable
 
   def convert
     frmt = PlantumlHelper.check_format(params[:content_type])

--- a/init.rb
+++ b/init.rb
@@ -5,7 +5,7 @@ Redmine::Plugin.register :plantuml do
   version '0.5.1'
   url 'https://github.com/dkd/plantuml'
 
-  requires_redmine version: '2.6'..'4.1'
+  requires_redmine version: '2.6'..'6.0'
 
   settings(partial: 'settings/plantuml',
            default: { 'plantuml_binary' => {}, 'cache_seconds' => '0', 'allow_includes' => false })

--- a/test/functional/plantuml_controller_test.rb
+++ b/test/functional/plantuml_controller_test.rb
@@ -4,28 +4,28 @@ class PlantumlControllerTest < ActionController::TestCase
   def setup
     @request.session[:user_id] = 1
     Setting.default_language = 'en'
-  end
 
-  class PlantumlHelper
-    def self.plantuml_file(name, extension)
-      File.open(File.expand_path("../../fixtures/files/#{name}.#{extension}", __FILE__), mode='r')
-    end
+    PlantumlHelper.singleton_class.prepend(Module.new do
+      def plantuml_file(name, extension)
+        File.open(File.expand_path("../../fixtures/files/#{name}#{extension}", __FILE__), mode='r')
+      end
+    end)
   end
 
   def test_convert_with_svg
-    get :convert, content_type: 'svg', filename: 'plantuml_0c40679fe8cc7b2f654444c35ff1ab7ba53a28768f7f89b9c457d500b76f5590'
+    get :convert, params: { content_type: 'svg', filename: 'plantuml_0c40679fe8cc7b2f654444c35ff1ab7ba53a28768f7f89b9c457d500b76f5590' }
     assert_response :success
     assert_equal 'image/svg+xml', @response.content_type
   end
 
   def test_convert_with_png
-    get :convert, content_type: 'png', filename: 'plantuml_0c40679fe8cc7b2f654444c35ff1ab7ba53a28768f7f89b9c457d500b76f5590'
+    get :convert, params: { content_type: 'png', filename: 'plantuml_0c40679fe8cc7b2f654444c35ff1ab7ba53a28768f7f89b9c457d500b76f5590' }
     assert_response :success
     assert_equal 'image/png', @response.content_type
   end
 
   def test_convert_default_with_png
-    get :convert, content_type: 'jpeg', filename: 'plantuml_0c40679fe8cc7b2f654444c35ff1ab7ba53a28768f7f89b9c457d500b76f5590'
+    get :convert, params: { content_type: 'jpeg', filename: 'plantuml_0c40679fe8cc7b2f654444c35ff1ab7ba53a28768f7f89b9c457d500b76f5590' }
     assert_response :success
     assert_equal 'image/png', @response.content_type
   end

--- a/test/unit/plantuml_macro_test.rb
+++ b/test/unit/plantuml_macro_test.rb
@@ -6,7 +6,7 @@ class PlantumlMacroTest < ActionController::TestCase
   include ERB::Util
 
   def setup
-    Setting.plugin_plantuml['plantuml_binary_default'] = '/usr/bin/plantuml'
+    Setting.plugin_plantuml['plantuml_binary_default'] = ENV['REDMINE_PLANTUML_EXECUTABLE'] || '/usr/bin/plantuml'
   end
 
   def test_plantuml_macro_with_png


### PR DESCRIPTION
Hello,

This update makes the plugin compatible with Redmine version 6.0.

To achieve this,

* it conditionally calls the `unloadable` method,
* updates test cases to accommodate newer Rails API changes,
* updates the Redmine version requirement, and
* enables setting the PlantUML executable path during testing.

Thank you,
gemmaro.
